### PR TITLE
Add wapi_version variable

### DIFF
--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -15,6 +15,12 @@
     type: "string"
     secret: false
     required: true
+  wapi_version:
+    description: "Hostname of Infloblox"
+    type: "string"
+    secret: false
+    required: false
+    default: "v2.9"
   verify_ssl:
     description: "Verify SSL of Infoblox API"
     default: true


### PR DESCRIPTION
Update configuration to take specific wapi API version, this is a standard variable in the infoblox-client.